### PR TITLE
Windows friendly Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 include mkinc.mak
+
+ifeq ($(OS),Windows_NT)
+	RM = "C:\Program Files\CMake\bin\cmake.exe" -E remove -f
+else
+	RM = rm -f
+endif
 CFLAGS=-Iinclude -fPIC
+
 all: libstemmer.o stemwords
+
 libstemmer.o: $(snowball_sources:.c=.o)
 	$(AR) -cru $@ $^
+
 stemwords: examples/stemwords.o libstemmer.o
 	$(CC) -o $@ $^
+
 clean:
-	rm -f stemwords *.o src_c/*.o runtime/*.o libstemmer/*.o examples/*.o
+	$(RM) *.o src_c/*.o runtime/*.o libstemmer/*.o examples/*.o


### PR DESCRIPTION
This allows compilation on Windows via `mingw32-make.exe` + `cmake`. Also a possible candidate for a PR to the upstream project.